### PR TITLE
Fix a panic situation on KSecretKey::from_str

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -188,15 +188,23 @@ impl From<Box<dyn Error + Send + Sync>> for SignatureError {
 
 /// Error returned by `KSecretKey::from_str` when the secret key cannot fit in the expected size.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KeyTooLongError;
+pub enum KeyLengthError {
+    /// The key is too long.
+    TooLong,
+    /// The key is too short.
+    TooShort,
+}
 
-impl Display for KeyTooLongError {
+impl Display for KeyLengthError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        f.write_str("Key too long")
+        match self {
+            KeyLengthError::TooLong => f.write_str("Key too long"),
+            KeyLengthError::TooShort => f.write_str("Key too short"),
+        }
     }
 }
 
-impl Error for KeyTooLongError {}
+impl Error for KeyLengthError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         crypto::{hmac_sha256, SHA256_OUTPUT_LEN},
-        KeyTooLongError,
+        KeyLengthError,
     },
     chrono::NaiveDate,
     derive_builder::Builder,
@@ -147,13 +147,16 @@ impl Display for KSigningKey {
 }
 
 impl<const M: usize> FromStr for KSecretKey<M> {
-    type Err = KeyTooLongError;
+    type Err = KeyLengthError;
 
     /// Create a new `KSecretKey` from a raw AWS secret key.
-    fn from_str(raw: &str) -> Result<Self, KeyTooLongError> {
+    fn from_str(raw: &str) -> Result<Self, KeyLengthError> {
         let len = raw.len();
         if len > M - 4 {
-            return Err(KeyTooLongError);
+            return Err(KeyLengthError::TooLong);
+        }
+        if len + 4 < M {
+            return Err(KeyLengthError::TooShort);
         }
 
         let mut prefixed_key = [0; M];


### PR DESCRIPTION
This slightly rewrites the handler for `from_str` to check if the input's too short - if a too-short value was passed in, the function would panic. This changes the error from a struct to an enum and adds tests for all three conditions (short, long and just right).

 