### PR TITLE
replace unmaintained 'encoding' crate with 'encoding_rs' (RUSTSEC-2021-0153)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ unstable = []
 bytes = "^1.10.1"
 chrono = { version = "^0.4.41", default-features = false, features = [] }
 derive_builder = "^0.20.2"
-encoding = "^0.2.33"
+encoding_rs = "^0.8"
 hex = "^0.4.3"
 hmac = "^0.12.1"
 http = "^1.3.1"

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -17,7 +17,7 @@ use {
     },
     bytes::Bytes,
     chrono::{offset::FixedOffset, DateTime, Utc},
-    encoding::{all::UTF_8, label::encoding_from_whatwg_label, types::DecoderTrap},
+    encoding_rs::UTF_8,
     http::{
         header::{HeaderMap, HeaderValue},
         request::{Parts, Request},
@@ -119,7 +119,7 @@ impl CanonicalRequest {
                     trace!("Body is application/x-www-form-urlencoded; converting to query parameters");
 
                     let encoding = match &content_type.charset {
-                        Some(charset) => match encoding_from_whatwg_label(charset.as_str()) {
+                        Some(charset) => match encoding_rs::Encoding::for_label(charset.as_bytes()) {
                             Some(encoding) => encoding,
                             None => {
                                 return Err(SignatureError::InvalidBodyEncoding(format!(
@@ -134,17 +134,15 @@ impl CanonicalRequest {
                         }
                     };
 
-                    let body_query = match encoding.decode(&body, DecoderTrap::Strict) {
-                        Ok(body) => body,
-                        Err(_) => {
-                            return Err(SignatureError::InvalidBodyEncoding(format!(
+                    let (body_query, _, has_errors) = encoding.decode(&body);
+                    if has_errors {
+                        return Err(SignatureError::InvalidBodyEncoding(format!(
                             "Invalid body data encountered parsing application/x-www-form-urlencoded with charset '{}'",
-                            encoding.whatwg_name().unwrap_or(encoding.name())
-                        )))
-                        }
-                    };
+                            encoding.name()
+                        )));
+                    }
 
-                    query_parameters.extend(query_string_to_normalized_map(body_query.as_str())?);
+                    query_parameters.extend(query_string_to_normalized_map(&body_query)?);
                     // Rebuild the parts URI with the new query string.
                     let qs = canonicalize_query_to_string(&query_parameters);
                     trace!("Rebuilding URI with new query string: {}", qs);
@@ -1688,7 +1686,7 @@ mod tests {
         if let SignatureError::InvalidBodyEncoding(msg) = e {
             assert_eq!(
                 msg.as_str(),
-                "Invalid body data encountered parsing application/x-www-form-urlencoded with charset 'utf-8'"
+                "Invalid body data encountered parsing application/x-www-form-urlencoded with charset 'UTF-8'"
             )
         } else {
             panic!("Unexpected error: {:?}", e);


### PR DESCRIPTION
# Description:
Context: This PR replaces the encoding crate with encoding_rs to resolve the security advisory [RUSTSEC-2021-0153](https://rustsec.org/advisories/RUSTSEC-2021-0153.html). The original _encoding_  crate has been unmaintained since 2016 and causes cargo audit / deny to fail in downstream projects that rely on scratchstack-aws-signature.

# Changes Made:

I've kept the changes to the absolute minimum necessary to make the project compile and pass tests again
You can read the diffs, there isn't much